### PR TITLE
"Make AWS Account ID variable for new cloud accounts and for better SMP onboarding experience"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ data "aws_iam_policy_document" "harness_ce" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::891928451355:root"]
+      identifiers = ["arn:aws:iam::${var.aws_account_id}:root"]
     }
 
     condition {

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,6 @@ variable "s3_bucket_arn" {
 variable "aws_account_id" {
   description = "AWS account ID"
   type        = string
-  # You can set a default value here if needed
   default     = "891928451355"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,9 +4,16 @@ variable "s3_bucket_arn" {
   default     = ""
 }
 
+variable "aws_account_id" {
+  description = "AWS account ID"
+  type        = string
+  # You can set a default value here if needed
+  default     = "891928451355"
+}
+
 variable "external_id" {
   type        = string
-  description = "External ID given in the harness UI: harness:891928451355:<guid>"
+  description = "External ID given in the harness UI: harness:<aws_account_id>:<guid>"
 }
 
 variable "enable_billing" {


### PR DESCRIPTION
For review from Riley and/or Nikunj. Want to have this available for seamless onboarding with SMP customers downstream. I believe this is all I would need to change.