### PR TITLE
remove ec2:* from lambda role

### DIFF
--- a/autostopping_lambda.tf
+++ b/autostopping_lambda.tf
@@ -27,7 +27,6 @@ data "aws_iam_policy_document" "harness_optimsationlambda" {
       "ec2:CreateNetworkInsightsPath",
       "ec2:CreateNetworkInterfacePermission",
       "ec2:CreateNetworkAcl",
-      "ec2:*",
       "ec2:CreateNetworkAclEntry",
       "logs:CreateLogGroup",
       "logs:CreateLogStream",


### PR DESCRIPTION
Lambda execution role is required for ALB based AutoStopping rules. We are creating a Lambda function as part of creating/importing a LoadBalancer(ALB) entity in Harness portal. The created Lambda function is added to a specific target group. This target group becomes the target of an ALB based AutoStopping rule when the rule is in down state(cool down). Traffic has to be forwarded to the Lambda as and when this target group receive traffic. This requires Lambda execution role to be assigned to assigned to the target group. 

ec2:* is not actually needed.